### PR TITLE
Update tracker-react-mixin.js

### DIFF
--- a/tracker-react-mixin.js
+++ b/tracker-react-mixin.js
@@ -19,7 +19,7 @@ TrackerReact = {
     //Meteor's various reactive data sources AND React's functional + unidirectional re-running of 
     //everything in component branches with state changes. 
 
-    autorunRender(prop) {
+    autorunRender() {
         let oldRender = this.render;
 
         this.render = () => {


### PR DESCRIPTION
Seems like there is an unused parameter in `autorunRender()` method
